### PR TITLE
Change android package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,10 +239,10 @@ If you'd like to understand what each method does, you can read about it [on Kla
 
 ## Example
 
-In addition to the test app in `/TestApp`, the you can see an abridged version below. 
+In addition to the test app in [/TestApp](https://github.com/klarna/react-native-klarna-inapp-sdk/tree/master/TestApp), the you can see an abridged version below.
 
 ```jsx
-import KlarnaPaymentView from 'react-native-klarna-payment-view';
+import KlarnaPaymentView from 'react-native-klarna-inapp-sdk';
 
 class MyCheckoutView extends React.Component {
 

--- a/TestApp/android/app/src/main/java/com/testapp/MainApplication.java
+++ b/TestApp/android/app/src/main/java/com/testapp/MainApplication.java
@@ -3,7 +3,7 @@ package com.testapp;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
-import com.klarna.KlarnaPaymentViewPackage;
+import com.klarna.inapp.sdk.KlarnaPaymentViewPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.klarna">
+          package="com.klarna.inapp.sdk">
 
 </manifest>

--- a/android/src/main/java/com/klarna/inapp/sdk/KlarnaPaymentEvent.java
+++ b/android/src/main/java/com/klarna/inapp/sdk/KlarnaPaymentEvent.java
@@ -1,4 +1,4 @@
-package com.klarna;
+package com.klarna.inapp.sdk;
 
 import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;

--- a/android/src/main/java/com/klarna/inapp/sdk/KlarnaPaymentViewManager.java
+++ b/android/src/main/java/com/klarna/inapp/sdk/KlarnaPaymentViewManager.java
@@ -1,4 +1,4 @@
-package com.klarna;
+package com.klarna.inapp.sdk;
 
 import android.app.Application;
 import android.util.Log;

--- a/android/src/main/java/com/klarna/inapp/sdk/KlarnaPaymentViewPackage.java
+++ b/android/src/main/java/com/klarna/inapp/sdk/KlarnaPaymentViewPackage.java
@@ -1,4 +1,4 @@
-package com.klarna;
+package com.klarna.inapp.sdk;
 
 import android.app.Application;
 

--- a/android/src/main/java/com/klarna/inapp/sdk/PaymentViewWrapper.java
+++ b/android/src/main/java/com/klarna/inapp/sdk/PaymentViewWrapper.java
@@ -1,4 +1,4 @@
-package com.klarna;
+package com.klarna.inapp.sdk;
 
 import android.util.AttributeSet;
 import android.util.Log;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-klarna-payment-view",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-klarna-inapp-sdk",
   "title": "React Native Klarna In-App SDK",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "This library wraps Klarna’s In-App SDK and exposes its functionality as React Native components. It currently supports Klarna Payments via a Payment View component.",
   "main": "index.js",
   "scripts": {},


### PR DESCRIPTION
Changed the android package name from "com.klarna" to "com.klarna.inapp.sdk". This was required to avoid package name conflicts in our internal apps which their package name was the same ("com.klarna").

Bumped to v1.0.7.