### PR TITLE
Update gradle.properties

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -15,4 +15,3 @@ org.gradle.jvmargs=-Xmx1536m
 kotlin.code.style=official
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableUnitTestBinaryResources=true


### PR DESCRIPTION
Removed android.enableUnitTestBinaryResources=true 
This is because it is deprecated in android 4 and thus the build will fail for anybody using android 4.


* What went wrong:
A problem occurred evaluating project ':react-native-klarna-inapp-sdk'.
> Failed to apply plugin [id 'com.android.internal.library']
   > The option 'android.enableUnitTestBinaryResources' is deprecated.
     The current default is 'false'.
     It has been removed from the current version of the Android Gradle plugin.
     The raw resource for unit test functionality is removed.

