### PR TITLE
react native 0.68 fix

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -103,7 +103,8 @@ afterEvaluate { project ->
     task androidJavadoc(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
         classpath += files(android.bootClasspath)
-        classpath += files(project.getConfigurations().getByName('compile').asList())
+        project.getConfigurations().getByName('implementation').setCanBeResolved(true)
+        classpath += files(project.getConfigurations().getByName('implementation').asList())
         include '**/*.java'
     }
 


### PR DESCRIPTION
Remove reference to deprecated "compile" configuration for compatibility with Gradle 7