### PR TITLE
chore: add ios component provider to codegen config

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,13 @@
     "jsSrcsDir": "src/specs",
     "android": {
       "javaPackageName": "com.klarna.mobile.sdk.reactnative"
+    },
+    "ios": {
+      "componentProvider": {
+        "RNKlarnaStandaloneWebView": "KlarnaStandaloneWebViewWrapper",
+        "RNKlarnaCheckoutView": "KlarnaCheckoutViewWrapper",
+        "RNKlarnaPaymentView": "PaymentViewWrapper"
+      }
     }
   }
 }


### PR DESCRIPTION
Added the component provider specification for iOS in the codegen config used by `RCTAppDependencyProvider` in React Native 0.77+ with the new architecture enabled.