### PR TITLE
Kotlin and kotlin serialization fix

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,7 +45,7 @@ def supportsNamespace() {
 }
 
 plugins {
-    id "org.jetbrains.kotlin.plugin.serialization" version "2.2.0"
+    id "org.jetbrains.kotlin.plugin.serialization" version "1.9.25"
 }
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
@@ -112,7 +112,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${getExtOrDefault('kotlinVersion')}"
     implementation "org.jetbrains.kotlin:kotlin-reflect:${getExtOrDefault('kotlinVersion')}"
-    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3'
 
     implementation 'com.klarna.mobile:sdk:2.7.1'
 

--- a/android/src/main/java/com/klarna/mobile/sdk/reactnative/common/util/ParserUtil.kt
+++ b/android/src/main/java/com/klarna/mobile/sdk/reactnative/common/util/ParserUtil.kt
@@ -19,9 +19,5 @@ object ParserUtil {
         return res
     }
 
-    inline fun <reified T> toJson(
-        src: T,
-    ): String = json.encodeToString(src)
-
     fun parse(json: String): JsonElement = this.json.parseToJsonElement(json)
 }

--- a/android/src/main/java/com/klarna/mobile/sdk/reactnative/signin/KlarnaSignInModuleImpl.java
+++ b/android/src/main/java/com/klarna/mobile/sdk/reactnative/signin/KlarnaSignInModuleImpl.java
@@ -38,21 +38,25 @@ public class KlarnaSignInModuleImpl implements KlarnaEventHandler {
     /* Module private methods */
 
     private KlarnaEnvironment environmentFrom(@NonNull String value) {
-        return switch (value) {
-            case "playground" -> KlarnaEnvironment.PLAYGROUND;
-            case "staging" -> KlarnaEnvironment.STAGING;
-            default -> KlarnaEnvironment.PRODUCTION;
-        };
-
+        switch (value) {
+            case "playground":
+                return KlarnaEnvironment.PLAYGROUND;
+            case "staging":
+                return KlarnaEnvironment.STAGING;
+            default:
+                return KlarnaEnvironment.PRODUCTION;
+        }
     }
 
     private KlarnaRegion regionFrom(@NonNull String value) {
-        return switch (value) {
-            case "na" -> KlarnaRegion.NA;
-            case "oc" -> KlarnaRegion.OC;
-            default -> KlarnaRegion.EU;
-        };
-
+        switch (value) {
+            case "na":
+                return KlarnaRegion.NA;
+            case "oc":
+                return KlarnaRegion.OC;
+            default:
+                return KlarnaRegion.EU;
+        }
     }
 
     private KlarnaSignInData getInstanceData(KlarnaComponent component) {

--- a/android/src/test/java/com/klarna/mobile/sdk/reactnative/common/util/ParserUtilTest.kt
+++ b/android/src/test/java/com/klarna/mobile/sdk/reactnative/common/util/ParserUtilTest.kt
@@ -14,20 +14,6 @@ internal class ParserUtilTest {
         assertNotNull(ParserUtil.json)
     }
 
-    @Test
-    fun `test toJson success`() {
-        val serialized = ParserUtil.toJson(TestData("test"))
-        assertEquals("{\"data\":\"test\"}", serialized)
-    }
-
-    @Test
-    fun `test toJson fail`() {
-        val testData = NonSerializableData("")
-        assertFailsWith(SerializationException::class, "test") {
-            ParserUtil.toJson(testData)
-        }
-    }
-
     @Serializable
     private data class TestData(
         @SerialName("data") val data: String,

--- a/ios/Sources/signIn/KlarnaSignInModule.h
+++ b/ios/Sources/signIn/KlarnaSignInModule.h
@@ -8,7 +8,9 @@
 
 #import <Foundation/Foundation.h>
 #import <React/RCTBridgeModule.h>
+#ifdef RCT_NEW_ARCH_ENABLED
 #import <RNKlarnaMobileSDK/RNKlarnaMobileSDK.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ios/Sources/signIn/KlarnaSignInModule.h
+++ b/ios/Sources/signIn/KlarnaSignInModule.h
@@ -8,6 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #import <React/RCTBridgeModule.h>
+#import <KlarnaMobileSDK/KlarnaMobileSDK.h>
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <RNKlarnaMobileSDK/RNKlarnaMobileSDK.h>
 #endif

--- a/package.json
+++ b/package.json
@@ -98,5 +98,20 @@
       "module",
       "typescript"
     ]
+  },
+  "codegenConfig": {
+    "name": "RNKlarnaMobileSDK",
+    "type": "all",
+    "jsSrcsDir": "src/specs",
+    "android": {
+      "javaPackageName": "com.klarna.mobile.sdk.reactnative"
+    },
+    "ios": {
+      "componentProvider": {
+        "RNKlarnaStandaloneWebView": "KlarnaStandaloneWebViewWrapper",
+        "RNKlarnaCheckoutView": "KlarnaCheckoutViewWrapper",
+        "RNKlarnaPaymentView": "PaymentViewWrapper"
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clean": "del-cli android/build ios/build TestApp/android/build TestApp/android/app/build TestApp/ios/build",
     "pods": "pod-install --quiet",
     "test:android": "cd TestApp/android && ./gradlew :react-native-klarna-inapp-sdk:testDebugUnitTest && cd ../..",
-    "test:ios": "cd ios && xcodebuild test -workspace RNKlarnaMobileSDK.xcworkspace -scheme RNKlarnaMobileSDK -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15'",
+    "test:ios": "cd ios && xcodebuild test -workspace RNKlarnaMobileSDK.xcworkspace -scheme RNKlarnaMobileSDK -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16'",
     "build:android": "cd TestApp/android && ./gradlew assembleDebug --no-daemon --console=plain -PreactNativeArchitectures=arm64-v8a",
     "build:ios": "cd TestApp/ios && xcodebuild -workspace TestApp.xcworkspace -scheme TestApp -configuration Debug -sdk iphonesimulator CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO",
     "TestApp": "yarn --cwd TestApp"
@@ -98,20 +98,5 @@
       "module",
       "typescript"
     ]
-  },
-  "codegenConfig": {
-    "name": "RNKlarnaMobileSDK",
-    "type": "all",
-    "jsSrcsDir": "src/specs",
-    "android": {
-      "javaPackageName": "com.klarna.mobile.sdk.reactnative"
-    },
-    "ios": {
-      "componentProvider": {
-        "RNKlarnaStandaloneWebView": "KlarnaStandaloneWebViewWrapper",
-        "RNKlarnaCheckoutView": "KlarnaCheckoutViewWrapper",
-        "RNKlarnaPaymentView": "PaymentViewWrapper"
-      }
-    }
   }
 }


### PR DESCRIPTION
- Kotlin plugin serialization downgraded to version 1.9.25 to allow compatibility with kotlin versions < 2.0.0
- Dependency org.jetbrains.kotlinx:kotlinx-serialization-json downgraded to version 1.6.3
- Updated KlarnaSignInModuleImpl.java switch statements to make them compatible with Java versions 8 and greater.
- Updated KlarnaSignInModule.h header imports.