### PR TITLE
Fix checkout content not being displayed issue on Android

### DIFF
--- a/android/src/main/java/com/klarna/mobile/sdk/reactnative/checkout/KlarnaCheckoutViewManager.java
+++ b/android/src/main/java/com/klarna/mobile/sdk/reactnative/checkout/KlarnaCheckoutViewManager.java
@@ -3,6 +3,7 @@ package com.klarna.mobile.sdk.reactnative.checkout;
 import android.os.Handler;
 import android.os.Looper;
 import android.view.View;
+import android.webkit.WebView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -57,13 +58,36 @@ public class KlarnaCheckoutViewManager extends RNKlarnaCheckoutViewSpec<ResizeOb
             if (resizeObserverWrapperView == null) {
                 return;
             }
+
             Integer retries = setSnippetRetriesMap.getOrDefault(resizeObserverWrapperView, 0);
             if (retries == null || retries >= MAX_SET_SNIPPET_RETRIES) {
                 return;
             }
+
             String snippet = snippetMap.get(resizeObserverWrapperView);
+            if (snippet == null) {
+                return;
+            }
+
             handler.postDelayed(() -> {
-                if (klarnaCheckoutView != null && klarnaCheckoutView.getHeight() == 0) {
+                if (klarnaCheckoutView == null) {
+                    return;
+                }
+
+                boolean shouldRetry = false;
+
+                if (klarnaCheckoutView.getHeight() == 0) {
+                    shouldRetry = true;
+                }
+
+                if (klarnaCheckoutView.getChildAt(0) instanceof WebView) {
+                    WebView internalWebView = (WebView) klarnaCheckoutView.getChildAt(0);
+                    if (internalWebView != null && internalWebView.getHeight() == 0) {
+                        shouldRetry = true;
+                    }
+                }
+
+                if (shouldRetry) {
                     setSnippet(resizeObserverWrapperView, snippet);
                     setSnippetRetriesMap.put(resizeObserverWrapperView, retries + 1);
                 }

--- a/src/KlarnaCheckoutView.tsx
+++ b/src/KlarnaCheckoutView.tsx
@@ -41,6 +41,10 @@ export class KlarnaCheckoutView extends Component<
     this.isCheckoutViewReady = false;
   }
 
+  componentWillUnmount() {
+    this.isCheckoutViewReady = false;
+  }
+
   render() {
     return (
       <RNKlarnaCheckoutView

--- a/src/KlarnaCheckoutView.tsx
+++ b/src/KlarnaCheckoutView.tsx
@@ -105,13 +105,13 @@ export class KlarnaCheckoutView extends Component<
         ) => {
           const newHeight = Number(event.nativeEvent.height);
           if (newHeight !== this.state.nativeViewHeight) {
-            console.log('onResized', newHeight);
+            console.log(`onResized: new height is ${newHeight}`);
             this.setState({ nativeViewHeight: newHeight });
           }
         }}
         onCheckoutViewReady={() => {
           this.isCheckoutViewReady = true;
-          console.log('onCheckoutViewReady');
+          console.log('Native checkout view is ready.');
           if (this.snippet) {
             console.log('Setting the snippet...');
             this.setSnippet(this.snippet);
@@ -127,6 +127,10 @@ export class KlarnaCheckoutView extends Component<
     const view = this.checkoutViewRef.current;
     if (view != null && this.isCheckoutViewReady) {
       RNKlarnaCheckoutViewCommands.setSnippet(view, snippet);
+    } else {
+      console.log(
+        'setSnippet: checkout view is not ready yet. Will set snippet once ready.'
+      );
     }
   };
 
@@ -134,6 +138,8 @@ export class KlarnaCheckoutView extends Component<
     const view = this.checkoutViewRef.current;
     if (view != null && this.isCheckoutViewReady) {
       RNKlarnaCheckoutViewCommands.suspend(view);
+    } else {
+      console.log('suspend: checkout view is not ready.');
     }
   };
 
@@ -141,6 +147,8 @@ export class KlarnaCheckoutView extends Component<
     const view = this.checkoutViewRef.current;
     if (view != null && this.isCheckoutViewReady) {
       RNKlarnaCheckoutViewCommands.resume(view);
+    } else {
+      console.log('resume: checkout view is not ready.');
     }
   };
 }


### PR DESCRIPTION
This PR changes the "set snippet" retry logic so that we set the snippet in case either `KlarnaCheckoutView`'s height or its internal WebView height is zero.