### PR TITLE
Fix OIDC token permissions for npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Publish to npm
         if: steps.version-check.outputs.should_publish == 'true'
-        run: npm publish --provenance --access public
+        run: NODE_AUTH_TOKEN="" npm publish --provenance --access public
 
       - name: Create GitHub release
         if: steps.version-check.outputs.should_publish == 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,9 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
  - Add job-level `permissions` block with `contents: write` and `id-token: write` to the publish job
  - Fixes npm publish E404 caused by `id-token: write` not being granted at the job level when triggered via `workflow_run`
  - Workflow-level permissions alone were insufficient — the runner only received `contents: write` and `metadata: read`, causing OIDC authentication to fail